### PR TITLE
Fix release download URLs to match actual dpkg artifact filenames

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -30,7 +30,9 @@ jobs:
           # If it's a tag, use the tag name as the version (e.g., v25.07.3 -> v25.07.3)
           # Otherwise, use CalVer + run number for development builds
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            VERSION="${{ github.ref_name }}"
+            # Strip 'v' prefix and normalize leading zeros to match dpkg versioning
+            RAW="${{ github.ref_name }}"
+            VERSION=$(echo "${RAW#v}" | awk -F. '{printf "%d.%d.%d", $1, $2, $3}')
           else
             # For main branch builds, use CalVer + run number as patch + 'dev' tag
             VERSION="${DATE_VERSION}.${GITHUB_RUN_NUMBER}-dev"


### PR DESCRIPTION
Strip 'v' prefix and normalize leading zeros from VERSION so that release notes URLs match the filenames nfpm/dpkg actually produces (e.g., k8s-tools_26.3.1-1_amd64.deb instead of k8s-tools_v26.03.1-1_amd64.deb).
